### PR TITLE
Rename issues

### DIFF
--- a/plugin/draftin.vim
+++ b/plugin/draftin.vim
@@ -142,8 +142,8 @@ function! s:Draft(...)
     endif
 
     let l:name = ""
-    if len(a:000) == 1
-        let l:name = a:1
+    if len(a:000) > 0
+        let l:name = join(a:000, ' ')
     else
         let l:name = getline(1)
         " Use filename if there's no first line.
@@ -161,6 +161,7 @@ function! s:Draft(...)
         endif
 
         let l:creating = 0
+        let l:name = b:draftin_name
     endif
 
     " Escaping the content is rather messy, since 
@@ -186,10 +187,10 @@ function! s:Draft(...)
 
     let l:rawres = s:SendMessage(curl_method, l:jsondata, l:endpoint)
     if l:creating
+        " When creating/updating the content, we get the metadata in the
+        " reply, so we can use that directly instead of requesting it
         let l:res = ParseJSON(l:rawres)
         call s:WriteDocMetadata(l:res)
-        " Read it back so the stored variables can be used
-        call s:ReadDocMetadata()
     endif
 
     if l:creating

--- a/plugin/draftin.vim
+++ b/plugin/draftin.vim
@@ -119,7 +119,9 @@ function! s:DraftRename(name)
     endif
 
     call s:SendMessage('PUT', { 'name' : a:name }, s:DocUpdateEndpoint())
-    echo "Document renamed to " . a:name . ", see https://draftin.com/documents/" . b:draftin_id
+    call s:UpdateDocMetadata()
+
+    echo "Document renamed to " . b:draftin_name . ", see https://draftin.com/documents/" . b:draftin_id
 endfunction
 
 " Upload the current buffer to draftin.com

--- a/plugin/draftin.vim
+++ b/plugin/draftin.vim
@@ -145,10 +145,14 @@ function! s:Draft(...)
     if len(a:000) > 0
         let l:name = join(a:000, ' ')
     else
-        let l:name = getline(1)
-        " Use filename if there's no first line.
-        if strlen(l:name) < 1
-            let l:name = shellescape(expand('%:t')) 
+        if exists("b:draftin_name")
+            let l:name = b:draftin_name
+        else
+            let l:name = getline(1)
+            " Use filename if there's no first line.
+            if strlen(l:name) < 1
+                let l:name = shellescape(expand('%:t')) 
+            endif
         endif
     endif
 
@@ -161,7 +165,6 @@ function! s:Draft(...)
         endif
 
         let l:creating = 0
-        let l:name = b:draftin_name
     endif
 
     " Escaping the content is rather messy, since 


### PR DESCRIPTION
Turned out that the naming/renaming functionality never worked very well as an update (whether implicit via :w or via :Draft) would reset the name to the default (first line or filename). Also, :Draft didn't work very well if it was passed a name with spaces in it.

This pull request should fix those issues.
